### PR TITLE
avicii: overlay: Add pixel_pitch parameter

### DIFF
--- a/overlay/OPlusSystemUIResTarget/res/values/dimens.xml
+++ b/overlay/OPlusSystemUIResTarget/res/values/dimens.xml
@@ -39,4 +39,8 @@
 
     <!-- Location on the screen of the center of the physical power button. -->
     <dimen name="physical_power_button_center_screen_location_y">875px</dimen>
+
+    <!-- Microns/ums (1000 um = 1mm) per pixel for the given device. If unspecified, UI that
+         relies on this value will not be sized correctly. -->
+    <item name="pixel_pitch" format="float" type="dimen">61.77</item>
 </resources>


### PR DESCRIPTION
Pixel pitch is the number of microns per pixel on device. This is used to size the UDFPS icon.

Bug: 319894241
Flag: ACONFIG com.android.systemui.device_entry_udfps_refactor DEVELOPMENT
Test: manual